### PR TITLE
Remove team identifier so any dev can sign

### DIFF
--- a/src/BikeTag.xcodeproj/project.pbxproj
+++ b/src/BikeTag.xcodeproj/project.pbxproj
@@ -323,7 +323,6 @@
 				TargetAttributes = {
 					45AB7BA51A3A1D8B00E1961E = {
 						CreatedOnToolsVersion = 6.1;
-						DevelopmentTeam = CSBZ6R9U39;
 					};
 					45AB7BBC1A3A1D8B00E1961E = {
 						CreatedOnToolsVersion = 6.1;


### PR DESCRIPTION
### Motivation

Instead of having everyone share Michael's developer account, the project should allow anyone to sign.

The elevates the problem of trying to keep credentials in sync in the short term, but introduces some problems that will need to be sorted out in the future:
1. How to distribute credentials for beta builds.
2. How to distribute credentials for app store releases.

Does Jackpine have an Apple Business account?

@michaelkirk @ferndopolis @svevang 

Ideally, I would like to add the code signing assets:
- Keychain
- certs
- provisioning profiles

to the git index.
