### PR TITLE
surface auth error, and offer retry

### DIFF
--- a/src/BikeTag/Controllers/HomeViewController.swift
+++ b/src/BikeTag/Controllers/HomeViewController.swift
@@ -39,9 +39,27 @@ class HomeViewController: ApplicationViewController {
   override func viewDidLoad() {
     self.stylePrimaryButton(self.guessSpotButtonView)
     self.initializeDownSwipe()
+    self.refreshCurrentSpotAfterGettingApiKey()
+  }
+
+  func refreshCurrentSpotAfterGettingApiKey() {
+    let displayAuthenticationErrorAlert = { (error: NSError) -> () in
+      let alertController = UIAlertController(
+        title: "Unable to authenticate you.",
+        message: error.localizedDescription,
+        preferredStyle: .Alert)
+
+      let retryAction = UIAlertAction(title: "Retry", style: .Default) { (action) in
+        self.refreshCurrentSpotAfterGettingApiKey()
+      }
+      alertController.addAction(retryAction)
+
+      self.presentViewController(alertController, animated: true, completion: nil)
+    }
+
     ApiKey.ensureApiKey({
       self.refreshCurrentSpot()
-    })
+    }, errorCallback: displayAuthenticationErrorAlert)
   }
 
   func refreshCurrentSpot() {

--- a/src/BikeTag/Models/ApiKey.swift
+++ b/src/BikeTag/Models/ApiKey.swift
@@ -26,7 +26,7 @@ class ApiKey {
     self.userId = attributes["user_id"] as! Int
   }
 
-  class func ensureApiKey(successCallback: ()->()) {
+  class func ensureApiKey(successCallback: ()->(), errorCallback: (NSError)->()) {
     if let currentApiKey = getCurrentApiKey() {
       return successCallback()
     }
@@ -39,8 +39,9 @@ class ApiKey {
       successCallback()
     }
 
-    let logFailure = {(error: NSError)  in
+    let handleFailure = {(error: NSError) -> () in
       Logger.error("Error setting API Key: \(error)")
+      errorCallback(error)
     }
 
     if let apiKeyAttributes = defaults.dictionaryForKey("apiKey") {
@@ -48,7 +49,7 @@ class ApiKey {
       setCurrentApiKey(apiKeyAttributes)
     } else {
       Logger.info("Creating new API Key")
-      ApiKeysService().createApiKey(setCurrentApiKey, errorCallback: logFailure)
+      ApiKeysService().createApiKey(setCurrentApiKey, errorCallback: handleFailure)
     }
   }
 


### PR DESCRIPTION
If auth fails, display the error to the user, and offer a retry. This is helpful for intermittent network connectivity or in debugging an invalid server.
