### PR TITLE
Shared location manager

### DIFF
--- a/src/BikeTag.xcodeproj/project.pbxproj
+++ b/src/BikeTag.xcodeproj/project.pbxproj
@@ -75,6 +75,8 @@
 		45AB7BB81A3A1D8B00E1961E /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 45AB7BB61A3A1D8B00E1961E /* LaunchScreen.xib */; };
 		45B488851A9AB73B00C7E03F /* Spot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B488841A9AB73B00C7E03F /* Spot.swift */; };
 		45B6BD4B1ABCEA3200E9BCDA /* ParsedSpotTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45B6BD4A1ABCEA3200E9BCDA /* ParsedSpotTest.swift */; };
+		45C256641CEBFA190098E8FF /* LocationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FC97B81CEBAB5D00F2E642 /* LocationService.swift */; };
+		45C256651CEBFA1A0098E8FF /* LocationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45FC97B81CEBAB5D00F2E642 /* LocationService.swift */; };
 		45C757861CE291EB00E9FEE8 /* Platform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C757851CE291EB00E9FEE8 /* Platform.swift */; };
 		45C757871CE2928D00E9FEE8 /* Platform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C757851CE291EB00E9FEE8 /* Platform.swift */; };
 		45C757891CE2AAA000E9FEE8 /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45C757881CE2AAA000E9FEE8 /* Session.swift */; };
@@ -171,6 +173,7 @@
 		45D6B51C1CA8AE5C0047E7DA /* Color.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
 		45DB1F881B27BDCD0001EC8A /* SpotView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SpotView.swift; sourceTree = "<group>"; };
 		45E0ECDC1CAC13E30096C179 /* SadFaceView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SadFaceView.swift; sourceTree = "<group>"; };
+		45FC97B81CEBAB5D00F2E642 /* LocationService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationService.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -270,6 +273,7 @@
 		4581A5F81AB7C9BA004C871F /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				45FC97B81CEBAB5D00F2E642 /* LocationService.swift */,
 				454E11091B1927B200FBAAC3 /* ApiKeysService.swift */,
 				454E110A1B1927B200FBAAC3 /* ApiError.swift */,
 				4581A5F91AB7C9BA004C871F /* SpotsService.swift */,
@@ -588,6 +592,7 @@
 				45CDD4491CB9DB8E00CEC1DD /* DevicesService.swift in Sources */,
 				451CBD231B3ED5EB00CCF832 /* PrimaryButton.swift in Sources */,
 				451E51D31AB49AFA00849262 /* User.swift in Sources */,
+				45C256651CEBFA1A0098E8FF /* LocationService.swift in Sources */,
 				452897401A86827F00AD077E /* HomeViewController.swift in Sources */,
 				454E11121B19564500FBAAC3 /* ApiService.swift in Sources */,
 				45D6B51D1CA8AE5C0047E7DA /* Color.swift in Sources */,
@@ -617,6 +622,7 @@
 				451CBD241B3ED5EB00CCF832 /* PrimaryButton.swift in Sources */,
 				45CDD44A1CB9DB8E00CEC1DD /* DevicesService.swift in Sources */,
 				454E11131B19564500FBAAC3 /* ApiService.swift in Sources */,
+				45C256641CEBFA190098E8FF /* LocationService.swift in Sources */,
 				45939FE71CAB76C700360BE7 /* HomeViewController.swift in Sources */,
 				454E11061B19278F00FBAAC3 /* ApiKey.swift in Sources */,
 				45939FE61CAB76C300360BE7 /* NewSpotViewController.swift in Sources */,

--- a/src/BikeTag/AppDelegate.swift
+++ b/src/BikeTag/AppDelegate.swift
@@ -7,6 +7,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
   var window: UIWindow?
   var currentSession: Session = Session(currentSpots:SpotsCollection())
+  let locationService = LocationService()
 
   func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
 

--- a/src/BikeTag/Base.lproj/Main.storyboard
+++ b/src/BikeTag/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="89J-R4-vFb">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10117" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="89J-R4-vFb">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
@@ -61,10 +61,10 @@
                                 <rect key="frame" x="20" y="360" width="560" height="240"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FIn-33-XEw" userLabel="top spacer">
-                                        <rect key="frame" x="0.0" y="0.0" width="560" height="51"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="560" height="50"/>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Bike Tag is a game to..." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7S3-op-o0l">
-                                        <rect key="frame" x="131" y="24.5" width="298" height="32"/>
+                                        <rect key="frame" x="131" y="25" width="299" height="32"/>
                                         <fontDescription key="fontDescription" name="LeagueSpartan-Bold" family="League Spartan" pointSize="25"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
@@ -82,7 +82,7 @@
                                         </variation>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Share your spots with others." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rFW-DH-TP9">
-                                        <rect key="frame" x="149" y="104.5" width="261" height="22"/>
+                                        <rect key="frame" x="149" y="105" width="261" height="22"/>
                                         <fontDescription key="fontDescription" name="LeagueSpartan-Bold" family="League Spartan" pointSize="17"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
@@ -91,7 +91,7 @@
                                         </variation>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Ride your bike!" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7SR-1O-0F4">
-                                        <rect key="frame" x="213" y="126.5" width="134" height="22"/>
+                                        <rect key="frame" x="213" y="127" width="134" height="22"/>
                                         <fontDescription key="fontDescription" name="LeagueSpartan-Bold" family="League Spartan" pointSize="17"/>
                                         <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
@@ -100,7 +100,7 @@
                                         </variation>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xUd-N0-Fps">
-                                        <rect key="frame" x="212" y="164" width="135" height="41"/>
+                                        <rect key="frame" x="212" y="165" width="135" height="41"/>
                                         <fontDescription key="fontDescription" name="Knewave" family="Knewave" pointSize="25"/>
                                         <state key="normal" title="Let's Ride! ">
                                             <color key="titleColor" red="0.9882352941176471" green="0.050980392156862744" blue="0.10588235294117647" alpha="1" colorSpace="calibratedRGB"/>
@@ -117,7 +117,7 @@
                                         </connections>
                                     </button>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mNc-rW-Hal" userLabel="bottom spacer">
-                                        <rect key="frame" x="0.0" y="189" width="560" height="51"/>
+                                        <rect key="frame" x="0.0" y="190" width="560" height="50"/>
                                         <constraints>
                                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="16" id="Vfz-vD-bmD"/>
                                         </constraints>
@@ -128,15 +128,14 @@
                                 </subviews>
                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                 <constraints>
-                                    <constraint firstAttribute="centerX" secondItem="7S3-op-o0l" secondAttribute="centerX" id="42k-pT-7wf"/>
                                     <constraint firstItem="rFW-DH-TP9" firstAttribute="bottom" secondItem="7SR-1O-0F4" secondAttribute="top" id="EUp-Sd-9rW"/>
                                     <constraint firstAttribute="trailing" secondItem="mNc-rW-Hal" secondAttribute="trailing" id="FeK-Wb-w3I"/>
                                     <constraint firstItem="mNc-rW-Hal" firstAttribute="leading" secondItem="4KA-6Z-e3d" secondAttribute="leading" id="KFS-7I-2mv"/>
                                     <constraint firstAttribute="centerX" secondItem="hQM-1k-de1" secondAttribute="centerX" id="SYh-VU-Vyl"/>
                                     <constraint firstAttribute="centerX" secondItem="xUd-N0-Fps" secondAttribute="centerX" id="TSQ-2A-lUQ"/>
-                                    <constraint firstItem="hQM-1k-de1" firstAttribute="top" secondItem="7S3-op-o0l" secondAttribute="bottom" constant="26" id="X0r-P8-bw2"/>
+                                    <constraint firstItem="7S3-op-o0l" firstAttribute="centerX" secondItem="FIn-33-XEw" secondAttribute="centerX" id="X60-b6-WPE"/>
                                     <constraint firstItem="rFW-DH-TP9" firstAttribute="top" secondItem="hQM-1k-de1" secondAttribute="bottom" id="aUE-uW-bMy"/>
-                                    <constraint firstItem="7S3-op-o0l" firstAttribute="top" secondItem="FIn-33-XEw" secondAttribute="bottom" constant="-26" id="bwK-84-Job"/>
+                                    <constraint firstItem="hQM-1k-de1" firstAttribute="top" secondItem="7S3-op-o0l" secondAttribute="bottom" constant="26" id="cty-vV-J9w"/>
                                     <constraint firstItem="xUd-N0-Fps" firstAttribute="bottom" secondItem="mNc-rW-Hal" secondAttribute="top" constant="16" id="fB2-fF-eON"/>
                                     <constraint firstAttribute="centerX" secondItem="rFW-DH-TP9" secondAttribute="centerX" id="rBb-h2-uiN"/>
                                     <constraint firstItem="mNc-rW-Hal" firstAttribute="height" secondItem="FIn-33-XEw" secondAttribute="height" id="ro2-OE-RZh"/>
@@ -145,6 +144,7 @@
                                     <constraint firstItem="FIn-33-XEw" firstAttribute="top" secondItem="4KA-6Z-e3d" secondAttribute="top" id="uKi-BL-l3A"/>
                                     <constraint firstAttribute="bottom" secondItem="mNc-rW-Hal" secondAttribute="bottom" id="w2Q-hG-ASZ"/>
                                     <constraint firstItem="xUd-N0-Fps" firstAttribute="top" secondItem="7SR-1O-0F4" secondAttribute="bottom" constant="16" id="xMF-1y-lAV"/>
+                                    <constraint firstItem="7S3-op-o0l" firstAttribute="top" secondItem="4KA-6Z-e3d" secondAttribute="top" constant="25" id="yFA-3G-Rkx"/>
                                     <constraint firstAttribute="centerX" secondItem="7SR-1O-0F4" secondAttribute="centerX" id="yYS-pa-6fs"/>
                                 </constraints>
                             </view>
@@ -237,7 +237,7 @@
                                 <rect key="frame" x="0.0" y="436" width="600" height="164"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Will your friends find it?" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="a9v-9r-GSk">
-                                        <rect key="frame" x="20" y="69.5" width="560" height="25"/>
+                                        <rect key="frame" x="20" y="70" width="560" height="25"/>
                                         <fontDescription key="fontDescription" name="LeagueSpartan-Bold" family="League Spartan" pointSize="20"/>
                                         <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
@@ -463,7 +463,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="600" height="120"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This is just a test..." lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="i52-el-SDC">
-                                                <rect key="frame" x="16" y="12" width="142.5" height="20.5"/>
+                                                <rect key="frame" x="16" y="12" width="143" height="21"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
@@ -578,7 +578,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="keep this game going. " textAlignment="center" lineBreakMode="wordWrap" numberOfLines="5" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MSM-pN-Bhb">
-                                <rect key="frame" x="200.5" y="331.5" width="200" height="21.5"/>
+                                <rect key="frame" x="200" y="332" width="200" height="22"/>
                                 <constraints>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="40" id="nX2-Lt-xQw"/>
                                 </constraints>
@@ -592,7 +592,7 @@
                                 </variation>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="30:00" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cgP-jT-iPT" userLabel="Countdown Clock">
-                                <rect key="frame" x="220" y="269" width="160" height="62.5"/>
+                                <rect key="frame" x="220" y="269" width="160" height="63"/>
                                 <fontDescription key="fontDescription" name="LeagueSpartan-Bold" family="League Spartan" pointSize="50"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
@@ -663,7 +663,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Nope." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="h2W-YK-sze">
-                                <rect key="frame" x="212.5" y="81" width="175" height="70"/>
+                                <rect key="frame" x="213" y="81" width="175" height="70"/>
                                 <fontDescription key="fontDescription" name="LeagueSpartan-Bold" family="League Spartan" pointSize="56"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
@@ -678,7 +678,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="=(" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="u7Z-f5-vse" customClass="SadFaceView" customModule="BikeTag" customModuleProvider="target">
-                                <rect key="frame" x="249" y="239" width="102" height="122.5"/>
+                                <rect key="frame" x="249" y="239" width="102" height="123"/>
                                 <gestureRecognizers/>
                                 <fontDescription key="fontDescription" name="LeagueSpartan-Bold" family="League Spartan" pointSize="98"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
@@ -737,7 +737,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Shoot! Time's up." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="1Hn-dN-dFH">
-                                <rect key="frame" x="20" y="102.5" width="560" height="56"/>
+                                <rect key="frame" x="20" y="101" width="560" height="57"/>
                                 <fontDescription key="fontDescription" name="LeagueSpartan-Bold" family="League Spartan" pointSize="45"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
@@ -751,7 +751,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="=(" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="O5I-ZL-gsn" userLabel="Sad Face" customClass="SadFaceView" customModule="BikeTag" customModuleProvider="target">
-                                <rect key="frame" x="242" y="230" width="116" height="140"/>
+                                <rect key="frame" x="242" y="230" width="117" height="140"/>
                                 <fontDescription key="fontDescription" name="LeagueSpartan-Bold" family="League Spartan" pointSize="112"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>
@@ -927,7 +927,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="In a second, we'll ask for your permission to notify you when someone finds your spot." textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="3" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="qvp-pb-WYy">
-                                <rect key="frame" x="20" y="455.5" width="560" height="42.5"/>
+                                <rect key="frame" x="20" y="455" width="560" height="43"/>
                                 <fontDescription key="fontDescription" name="LeagueSpartan-Bold" family="League Spartan" pointSize="17"/>
                                 <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                                 <nil key="highlightedColor"/>

--- a/src/BikeTag/Controllers/HomeViewController.swift
+++ b/src/BikeTag/Controllers/HomeViewController.swift
@@ -47,8 +47,8 @@ class HomeViewController: ApplicationViewController, UIScrollViewDelegate, UITab
 
   required init?(coder aDecoder: NSCoder) {
     let appDelegate = UIApplication.sharedApplication().delegate as! AppDelegate
-    self.currentSpots = appDelegate.currentSession.currentSpots
-    self.locationService = appDelegate.locationService
+    currentSpots = appDelegate.currentSession.currentSpots
+    locationService = appDelegate.locationService
     super.init(coder:aDecoder)
   }
 

--- a/src/BikeTag/Controllers/NewSpotViewController.swift
+++ b/src/BikeTag/Controllers/NewSpotViewController.swift
@@ -17,29 +17,19 @@ class NewSpotViewController: CameraViewController {
   }
 
   func createSpotFromData(imageData: NSData, location: CLLocation) -> () {
-    var image: UIImage?
-    var spotLocation: CLLocation?
+    let image = Platform.isSimulator ? Spot.griffithSpot().image : UIImage(data: imageData)
 
-    // Fake photo when using the simulator
-    if Platform.isSimulator {
-      let griffithSpot = Spot.griffithSpot()
-      image = griffithSpot.image
-      spotLocation = griffithSpot.location
-    } else {
-      image = UIImage(data: imageData)
-      spotLocation = location
-    }
-
-    if ( image != nil ) {
-      if (self.game == nil) {
-        Logger.debug("No existing game, assuming new game.")
-        self.game = Game(id: nil)
-      }
-      let spot = Spot(image: image!, game: self.game!, user: User.getCurrentUser(), location: spotLocation!)
-      self.uploadNewSpot(spot)
-    } else {
+    guard ( image != nil ) else {
       Logger.error("New spot image data not captured")
+      return
     }
+
+    if (self.game == nil) {
+      Logger.debug("No existing game, assuming new game.")
+      self.game = Game(id: nil)
+    }
+    let spot = Spot(image: image!, game: self.game!, user: User.getCurrentUser(), location: location)
+    self.uploadNewSpot(spot)
   }
 
   @IBAction func takePictureButtonViewTouched(sender: AnyObject) {

--- a/src/BikeTag/Services/LocationService.swift
+++ b/src/BikeTag/Services/LocationService.swift
@@ -16,6 +16,11 @@ class LocationService: NSObject, CLLocationManagerDelegate {
   }
 
   func locationManager(manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+    guard (locations.last != nil) else {
+      Logger.error("location did update, but was nil")
+      return
+    }
+
     if( self.mostRecentLocation == nil ) {
       Logger.debug("Initialized location: \(locations.last)")
     }

--- a/src/BikeTag/Services/LocationService.swift
+++ b/src/BikeTag/Services/LocationService.swift
@@ -1,0 +1,53 @@
+import CoreLocation
+
+class LocationService: NSObject, CLLocationManagerDelegate {
+  let locationManager = CLLocationManager()
+  var mostRecentLocation: CLLocation?
+
+  required override init() {
+    super.init()
+    self.locationManager.delegate = self
+  }
+
+  func locationManager(manager: CLLocationManager,
+                       didChangeAuthorizationStatus status: CLAuthorizationStatus) {
+
+    startTrackingLocation(onDenied: { Logger.error("sneaky user disabled location authorization status.") } )
+  }
+
+  func locationManager(manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+    if( self.mostRecentLocation == nil ) {
+      Logger.debug("Initialized location: \(locations.last)")
+    }
+    self.mostRecentLocation = locations.last
+  }
+
+  // MARK: CLLocationManagerDelegate
+  func waitForLocation(onSuccess successCallback: (CLLocation)->(), onTimeout timeoutCallback: ()->()) {
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(2.0 * Double(NSEC_PER_SEC))), dispatch_get_main_queue()) { () -> Void in
+
+      // Don't bombard the user with a redundant warning if they are still reading the location authorization request.
+      if ( CLLocationManager.authorizationStatus() != CLAuthorizationStatus.AuthorizedAlways && CLLocationManager.authorizationStatus() != CLAuthorizationStatus.AuthorizedWhenInUse ) {
+        return self.waitForLocation(onSuccess:successCallback, onTimeout: timeoutCallback)
+      }
+
+      if let location = self.mostRecentLocation {
+        successCallback(location)
+      } else {
+        timeoutCallback()
+      }
+    }
+  }
+
+  func startTrackingLocation(onDenied deniedCallback: () -> ()) {
+    switch CLLocationManager.authorizationStatus() {
+    case .AuthorizedAlways, .AuthorizedWhenInUse:
+      locationManager.startUpdatingLocation()
+    case .NotDetermined:
+      locationManager.requestWhenInUseAuthorization()
+    case .Restricted, .Denied:
+      deniedCallback()
+    }
+  }
+
+}

--- a/src/BikeTag/Services/LocationService.swift
+++ b/src/BikeTag/Services/LocationService.swift
@@ -1,12 +1,11 @@
 import CoreLocation
 
 class LocationService: NSObject, CLLocationManagerDelegate {
-  let locationManager = CLLocationManager()
+  var locationManager: CLLocationManager?
   var mostRecentLocation: CLLocation?
 
   required override init() {
     super.init()
-    self.locationManager.delegate = self
   }
 
   func locationManager(manager: CLLocationManager,
@@ -45,11 +44,16 @@ class LocationService: NSObject, CLLocationManagerDelegate {
   }
 
   func startTrackingLocation(onDenied deniedCallback: () -> ()) {
+    if (locationManager == nil) {
+      locationManager = CLLocationManager()
+      locationManager!.delegate = self
+    }
+
     switch CLLocationManager.authorizationStatus() {
     case .AuthorizedAlways, .AuthorizedWhenInUse:
-      locationManager.startUpdatingLocation()
+      locationManager!.startUpdatingLocation()
     case .NotDetermined:
-      locationManager.requestWhenInUseAuthorization()
+      locationManager!.requestWhenInUseAuthorization()
     case .Restricted, .Denied:
       deniedCallback()
     }

--- a/src/BikeTag/Services/LocationService.swift
+++ b/src/BikeTag/Services/LocationService.swift
@@ -8,25 +8,6 @@ class LocationService: NSObject, CLLocationManagerDelegate {
     super.init()
   }
 
-  func locationManager(manager: CLLocationManager,
-                       didChangeAuthorizationStatus status: CLAuthorizationStatus) {
-
-    startTrackingLocation(onDenied: { Logger.error("sneaky user disabled location authorization status.") } )
-  }
-
-  func locationManager(manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-    guard (locations.last != nil) else {
-      Logger.error("location did update, but was nil")
-      return
-    }
-
-    if( self.mostRecentLocation == nil ) {
-      Logger.debug("Initialized location: \(locations.last)")
-    }
-    self.mostRecentLocation = locations.last
-  }
-
-  // MARK: CLLocationManagerDelegate
   func waitForLocation(onSuccess successCallback: (CLLocation)->(), onTimeout timeoutCallback: ()->()) {
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(2.0 * Double(NSEC_PER_SEC))), dispatch_get_main_queue()) { () -> Void in
 
@@ -59,4 +40,22 @@ class LocationService: NSObject, CLLocationManagerDelegate {
     }
   }
 
+  // MARK: CLLocationManagerDelegate
+  func locationManager(manager: CLLocationManager,
+                       didChangeAuthorizationStatus status: CLAuthorizationStatus) {
+
+    startTrackingLocation(onDenied: { Logger.error("sneaky user disabled location authorization status.") } )
+  }
+
+  func locationManager(manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+    guard (locations.last != nil) else {
+      Logger.error("location did update, but was nil")
+      return
+    }
+
+    if( self.mostRecentLocation == nil ) {
+      Logger.debug("Initialized location: \(locations.last)")
+    }
+    self.mostRecentLocation = locations.last
+  }
 }


### PR DESCRIPTION
Previously user had to wait a couple seconds for location on the spot list, spot-guess, and create-new-spot screens. 

By sharing a location manager across the app, we save our users from having to "wait for location" in all but the first instance. 

And in the process removed some redundant code and slimmed down my biggest controllers.